### PR TITLE
Bug fix for #27, CLI error

### DIFF
--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -1,12 +1,12 @@
-def run(orig_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
+def run(to_remap_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
     import gzip
     import sys
 
     import pysam
 
-    orig_bam = pysam.Samfile(orig_bam, "rb")
+    to_remap_bam = pysam.Samfile(to_remap_bam, "rb")
     remap_bam = pysam.Samfile(remap_bam, "rb")
-    keep_bam = pysam.Samfile(keep_bam, "wb", template=orig_bam)
+    keep_bam = pysam.Samfile(keep_bam, "wb", template=to_remap_bam)
     orig_num_file = gzip.open(orig_num_file)
 
     # correct_maps is a list of read pairs that mapped correctly. The read pair
@@ -71,7 +71,7 @@ def run(orig_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
 
     # Pull out original aligned reads if all of the alternatives mapped
     # correctly.
-    orig_read = orig_bam.next()
+    orig_read = to_remap_bam.next()
     # I believe orig_num is the number of different read pairs generated from
     # the original read pair (depends on number of alleles it overlapped).
     orig_num = int(orig_num_file.readline().strip())
@@ -90,14 +90,14 @@ def run(orig_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
             # If the data is paired end, write out the paired read.
             if is_paired_end:
                 try:
-                    orig_read = orig_bam.next()
+                    orig_read = to_remap_bam.next()
                 except:
                     sys.stderr.write("File ended unexpectedly (no pair found).")
                     exit()
                 keep_bam.write(orig_read)
             line_num += 1
             try:
-                orig_read = orig_bam.next()
+                orig_read = to_remap_bam.next()
                 orig_num = int(orig_num_file.readline().strip())
             except:
                 end_of_file = True
@@ -113,7 +113,7 @@ def run(orig_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
         #     # If the data is paired end, write out the paired read.
         #     if is_paired_end:
         #         try:
-        #             orig_read = orig_bam.next()
+        #             orig_read = to_remap_bam.next()
         #         except:
         #             sys.stderr.write("File ended unexpectedly (no pair found).")
         #             exit()
@@ -123,7 +123,7 @@ def run(orig_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
         #     line_num += 1
         #     correct = 0
         #     try:
-        #         orig_read = orig_bam.next()
+        #         orig_read = to_remap_bam.next()
         #         orig_num = int(orig_num_file.readline().strip())
         #     except:
         #         end_of_file = True
@@ -151,7 +151,7 @@ def main():
     
     options = parser.parse_args()
     
-    run(options.orig_bam, options.remap_bam, options.keep_bam,
+    run(options.to_remap_bam, options.remap_bam, options.keep_bam,
         options.orig_num_file, options.is_paired_end)
 
 if __name__ == '__main__':

--- a/mapping/test_filter_remapped_reads.py
+++ b/mapping/test_filter_remapped_reads.py
@@ -278,3 +278,29 @@ class TestRun:
         assert len(lines) == 2
 
         cleanup()
+
+class TestCLI:
+    def test_simple_single_cli(self):
+        is_paired_end = False
+        max_window = 100000
+        pref = 'test_data/test_single'
+        file_name = pref + ".sort.bam"
+        keep_file_name = pref + ".keep.bam"
+        remap_name = pref + ".to.remap.bam"
+        remap_num_name = pref + ".to.remap.num.gz"
+        fastq_names = [pref + ".remap.fq.gz"]
+        snp_dir = 'test_data/snps'
+        bs = BamScanner(is_paired_end, max_window, file_name, keep_file_name,
+                        remap_name, remap_num_name, fastq_names, snp_dir)
+        bs.run()
+
+        keep_bam = pref + '_filtered.bam'
+        c = ('python filter_remapped_reads.py {} {} {} {}'.format(
+            remap_name, 'test_data/test_single.remapped.bam', keep_bam,
+            remap_num_name))
+        subprocess.check_call(c, shell=True)
+
+        lines = read_bam(keep_bam)
+        assert len(lines) == 1
+
+        cleanup()

--- a/mapping/test_find_intersecting_snps.py
+++ b/mapping/test_find_intersecting_snps.py
@@ -303,3 +303,37 @@ class TestBamScanner:
             assert lines[i] == qual
 
         cleanup()
+
+class TestCLI:
+    def test_simple_single_cli(self):
+        """This test is to make sure the cli functions."""
+        pref = 'test_data/test_single'
+        c = ('python find_intersecting_snps.py {}.sort.bam '
+             'test_data/snps'.format(pref))
+        subprocess.check_call(c, shell=True)
+
+        # file_name = pref + ".sort.bam"
+        # keep_bam = pref + '_filtered.bam'
+        # run(remap_name, 'test_data/test_single.remapped.bam', keep_bam,
+        #     remap_num_name, is_paired_end)
+
+        # lines = read_bam(keep_bam)
+        # assert len(lines) == 1
+
+        seq = ('CATCAAGCCAGCCTTCCGCTCCTTGAAGCTGGTCTCCACACAGTGCTGGTTCCGTCACCCCC'
+               'TCCCAAGGAAGTAGGTCTGAGCAGCTTGTCCTGGCTGT')
+        qual = ('BBBBBFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
+                'FFFFFBFF<FFFFFFFFFBFFFFFFFFFFFFFFFFFFF')
+        with gzip.open('test_data/test_single.sort.remap.fq.gz') as f:
+            lines = [x.strip() for x in f.readlines()]
+        assert len(lines) == 4
+        assert lines[1] == seq
+        assert lines[3] == qual
+
+        # Verify to.remap bam is the same as the input bam file.
+        old_lines = read_bam('test_data/test_single.sort.sort.bam')
+        new_lines = read_bam('test_data/test_single.sort.to.remap.bam')
+        assert old_lines == new_lines
+        
+        cleanup()
+


### PR DESCRIPTION
I introduced a bug during refactoring that affects the cli for
filter_remapped_reads.py (reported as #27). I have fixed that bug as well as added
simple tests for both filter_remapped_reads.py and
find_intersecting_snps.py to make sure that calling the scripts from the
command line works for simple input.