### PR TITLE
Bug fix for issue #30

### DIFF
--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -108,8 +108,6 @@ def run(to_remap_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
     # pair because both reads mapped correctly. If the first number of
     # orig_num_file was 4, then we wouldn't keep the first read pair because
     # two of the reads didn't map correctly.
-    import pdb
-    # pdb.set_trace()
     while (not end_of_file and 
            (map_indx < len(correct_maps)) and 
            (line_num <= correct_maps[-1])):
@@ -130,8 +128,11 @@ def run(to_remap_bam, remap_bam, keep_bam, orig_num_file, is_paired_end):
             else:
                 second_read = to_remap_bam.next()
 
-            orig_read = to_remap_bam.next()
-            orig_num = int(orig_num_file.readline().strip())
+            try:
+                orig_read = to_remap_bam.next()
+                orig_num = int(orig_num_file.readline().strip())
+            except StopIteration:
+                end_of_file = True
             line_num += 1
             correct = 0
         else:

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -764,12 +764,14 @@ def main():
         pref = ".".join(name_split[:-1])
     else:
         pref = name_split[0]
-
+    
     if not options.is_sorted:
         pysam.sort(infile, pref + ".sort")
         infile = pref + ".sort"
+        sort_file_name = pref + ".sort.bam"
+    else:
+        sort_file_name = infile
 
-    sort_file_name = pref + ".sort.bam"
     keep_file_name = pref + ".keep.bam"
     remap_name = pref + ".to.remap.bam"
     remap_num_name = pref + ".to.remap.num.gz"


### PR DESCRIPTION
This fixes #30 by adding a check for the end of the remapped bam file and
appropriately exiting. I haven't added any tests for this but it should
be covered by a general test for single end input data for
filter_remapped_reads.py that we should make at some point. Also fixed a
bug in accepting already-sorted bam files for find_intersecting_snps.py.
The command would fail immediately when trying to use the -s option, so
this would have been obvious to anyone and likely hasn't caused any
unknown problems.