### PR TITLE
Unphased SNPs triggering 'unable to parse genotype' warning 

### DIFF
--- a/snp2h5/vcf.c
+++ b/snp2h5/vcf.c
@@ -172,11 +172,13 @@ void vcf_parse_haplotypes(VCFInfo *vcf_info, char *haplotypes,
 	  /* try with '/' separator instead */
 	  n = sscanf(inner_tok, "%d/%d", &hap1, &hap2);
 
-	  if(n == 2 && warn_phase) {
-	    my_warn("%s:%d: some genotypes are unphased (delimited "
-		    "with '/' instead of '|')\n", __FILE__, __LINE__,
-		    inner_tok);
-	    warn_phase = FALSE;
+	  if(n == 2) {
+	    if(warn_phase) {
+	      my_warn("%s:%d: some genotypes are unphased (delimited "
+		      "with '/' instead of '|')\n", __FILE__, __LINE__,
+		      inner_tok);
+	      warn_phase = FALSE;
+	    }
 	  } else {
 	    my_warn("%s:%d: could not parse genotype string '%s'\n",
 		    __FILE__, __LINE__, inner_tok);


### PR DESCRIPTION
Code checks if a SNP is unphased and if the warn_phase flag is
set in the same conditional.

After unsetting warn_phase, this test fails, causing additional unphased 
SNPs to trigger an 'unable to parse genotype' warning and converting 
genotypes to missing data.

By creating two separate conditionals, a single warning is printed and
all additional unphased SNPs are parsed normally.