### PR TITLE
Properly handle cases in which both reads in a pair map to the same coordinate

### DIFF
--- a/mapping/filter_remapped_reads.py
+++ b/mapping/filter_remapped_reads.py
@@ -103,7 +103,7 @@ def filter_reads(remap_bam):
                 
             # only use left end of reads, but check that right end is in
             # correct location
-            if read.pos < read.next_reference_start:
+            if read.pos < read.next_reference_start or (read.pos == read.next_reference_start and read.is_read1 and not read.is_read2):
                 if pos1 == read.pos+1 and pos2 == read.next_reference_start+1:
                     # both reads mapped to correct location
                     correct_map = True


### PR DESCRIPTION
If paired-end sequencing is used and a fragment has length less than
or equal to the read length, then both reads from that fragment should
map to the same coordinate. Previously, filter_remapped_reads.py skipped
over remapped pairs in which both reads map to the same location,
leading the original SNP-overlapping reads to be discarded. Now such
pairs should be properly handled.