### PR TITLE
Merge bugfix from gmcvicker/WASP

### DIFF
--- a/snp2h5/seq.c
+++ b/snp2h5/seq.c
@@ -192,11 +192,7 @@ void seq_write_fasta_record(Seq *seq, gzFile f) {
   int line_len;
 
   /* write header */
-  if(seq->name == NULL) {
-    gzprintf(f, ">\n");
-  } else {
-    gzprintf(f, ">%s\n", seq->name);
-  }
+  gzprintf(f, ">%s\n", seq->name);
 
   line_len = 0;
 

--- a/snp2h5/snp2h5.c
+++ b/snp2h5/snp2h5.c
@@ -485,7 +485,7 @@ void init_h5matrix(H5MatrixInfo *info,
 void write_h5matrix_row(H5MatrixInfo *info, hsize_t row_num,
 			void *row_data) {
   hsize_t offset[2];
-  hsize_t count[1];
+  hsize_t count[2];
   herr_t status;
   
   /* select a hyperslab that corresponds to a 


### PR DESCRIPTION
fix bug that could cause snp2h5 to write haplotypes incorrectly