### PR TITLE
 - fixing bug D and I CIGAR

### DIFF
--- a/CHT/bam2h5.py
+++ b/CHT/bam2h5.py
@@ -277,6 +277,12 @@ def choose_overlap_snp(read, snp_tab, snp_index_array, hap_tab, ind_idx):
             # end of read is soft-clipped, which means it is
             # present in read, but not used in alignment
             read_start_idx += op_len
+        elif op == BAM_CINS:
+            # Dealing with insertion
+            read_start_idx += op_len
+        elif op == BAM_CDEL:
+            # Dealing with deletion
+            genome_start_idx += op_len
         elif op == BAM_CHARD_CLIP:
             # end of read is hard-clipped, so not present
             # in read and not used in alignment


### PR DESCRIPTION
Hi,
I noticed that WASP does not handle correctly the D and I entries in CIGAR. That leads to incorrectly identify the nucleotide overlapping a SNP. Thus leading to an erroneous number of reads per allele.

The problem arises because when a D or I is encountered, WASP does not update the genomic start index (when D) or the read start index (when I) and therefore causing an unwanted shift between read and genome.

I implemented a fix for this.

Thanks,
Mingshi